### PR TITLE
glog wants to write to /tmp which doesn't exist in `FROM scratch` images

### DIFF
--- a/cmd/irc/bot.go
+++ b/cmd/irc/bot.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	irc "github.com/fluffle/goirc/client"
-	"github.com/fluffle/goirc/logging/glog"
 	"github.com/iggy/scurvy/pkg/config"
 	"github.com/iggy/scurvy/pkg/errors"
 	"github.com/iggy/scurvy/pkg/msgs"
@@ -26,7 +25,6 @@ var ircChannelname = "#testscurvybot"
 func main() {
 	log.Println("Initializing scurvy ircbot")
 	flag.Parse()
-	glog.Init()
 
 	config.ReadConfig()
 
@@ -36,6 +34,10 @@ func main() {
 	cfg.SSLConfig = &tls.Config{ServerName: ircServername}
 	cfg.Server = fmt.Sprintf("%s:%d", ircServername, ircPort)
 	cfg.NewNick = func(n string) string { return n + "^" }
+	// different Recover function that exits (vs just logging)
+	cfg.Recover = func(conn *irc.Conn, line *irc.Line) {
+		log.Panicln("Error in irc handler. Hopefully there's a useful error above.")
+	}
 	c := irc.Client(cfg)
 	c.EnableStateTracking()
 


### PR DESCRIPTION
We don't really need glog and it is causing issues with another recent change. Not entirely sure why this is just now biting us. It should have been failing all along.