### PR TITLE
Add a debug line to sort out an error in pymedusa

### DIFF
--- a/cmd/input-webhook/urlhandlers.go
+++ b/cmd/input-webhook/urlhandlers.go
@@ -78,6 +78,7 @@ func sickbeardHandler(w http.ResponseWriter, r *http.Request) {
 	// parse the json payload and figure out what they want to know
 	var jreq = JSONRPCRequest{}
 	if jerr := json.Unmarshal(body, &jreq); jerr != nil {
+		log.Printf("Failed to unmarshall json body: \n%v\n%v", jerr, body)
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(422) // unprocessable entity
 		eerr := json.NewEncoder(w).Encode(jerr)


### PR DESCRIPTION
Since moving from couchpotato to pymedusa, I'm seeing a warning in the
application logs when it tries to do a version check. This is just an
extra log line to help track down what the newer software is sending.