### PR TITLE
Add diskfull message handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# we set this here because buildx normally sets it for us, but
+# CircleCI doesn't support a new enough docker, so we have to
+# pass this arg manually when in CI
+ARG BUILDPLATFORM
+
 # Run tests stage (we only run this on the BUILDPLATFORM)
 FROM --platform=$BUILDPLATFORM golang:alpine as test
 

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ host_build: host_check
 # the same packages over and over
 # Also lets us use the same method to build locally and in travis
 docker:
-	docker build --pull --tag scurvy:test .
-	docker build --target build --tag scurvy:build .
-	docker build --target irc --tag notiggy/scurvy-irc .
-	docker build --target notifyd --tag notiggy/scurvy-notifyd .
-	docker build --target input-webhook --tag notiggy/scurvy-input-webhook .
+	docker build --build-arg=BUILDPLATFORM=linux/amd64 --pull --tag scurvy:test .
+	docker build --build-arg=BUILDPLATFORM=linux/amd64 --target build --tag scurvy:build .
+	docker build --build-arg=BUILDPLATFORM=linux/amd64 --target irc --tag notiggy/scurvy-irc .
+	docker build --build-arg=BUILDPLATFORM=linux/amd64 --target notifyd --tag notiggy/scurvy-notifyd .
+	docker build --build-arg=BUILDPLATFORM=linux/amd64 --target input-webhook --tag notiggy/scurvy-input-webhook .
 	# the below line needs a _very_ new version of docker (i.e. experimental)
 	# I will just run this locally for now, but need to hook it up to CI later
 	# docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t notiggy/scurvy-irc:latest --target irc --pull --push .

--- a/cmd/notifyd/scurvy-notify.go
+++ b/cmd/notifyd/scurvy-notify.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"runtime"
-
-	"encoding/json"
 
 	"github.com/iggy/scurvy/pkg/config"
 	"github.com/iggy/scurvy/pkg/errors"
@@ -13,25 +12,34 @@ import (
 	"github.com/iggy/scurvy/pkg/notify"
 
 	"github.com/nats-io/go-nats"
-	// "github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func handleNatsMsg(m *nats.Msg) {
 	log.Printf("Received on [%s]: '%s'\n", m.Subject, string(m.Data))
-	var jmsg = msgs.NewDownload{}
-	if jerr := json.Unmarshal(m.Data, &jmsg); jerr != nil {
-		log.Panicf("fatal error reading json msg from nats: %s", jerr)
-	}
 	if m.Subject == "scurvy.notify.newdownload" {
+		var jmsg = msgs.NewDownload{}
+		if jerr := json.Unmarshal(m.Data, &jmsg); jerr != nil {
+			log.Panicf("fatal error reading NewDownload json msg from nats: %s", jerr)
+		}
 		notify.SendGeneralSlack(fmt.Sprintf("Good news everyone! %s was downloaded to %s",
 			jmsg.Name, jmsg.Path))
 	}
 	if m.Subject == "scurvy.notify.faileddownload" {
+		var jmsg = msgs.FailedDownload{}
+		if jerr := json.Unmarshal(m.Data, &jmsg); jerr != nil {
+			log.Panicf("fatal error reading FailedDownload json msg from nats: %s", jerr)
+		}
 		notify.SendGeneralSlack(fmt.Sprintf("Bad news everyone! %s failed to downloaded to %s",
 			jmsg.Name, jmsg.Path))
 	}
-	// log.Printf("%s - %v - %v", m.Subject, m.Reply, m.Sub)
+	if m.Subject == "scurvy.notify.diskfull" {
+		var jmsg = msgs.DiskFull{}
+		if jerr := json.Unmarshal(m.Data, &jmsg); jerr != nil {
+			log.Panicf("fatal error reading DiskFull json msg from nats: %s", jerr)
+		}
+		notify.SendAdminSlack(fmt.Sprintf("Disk full: %s", jmsg.Message))
+	}
 }
 
 func main() {
@@ -51,7 +59,7 @@ func main() {
 
 	lerr := nc.LastError()
 	errors.CheckErr(lerr)
-	// sendAdminSlack("Initializing Scurvy Notification Daemon.")
+	notify.SendAdminSlack("Initializing Scurvy Notification Daemon.")
 
 	runtime.Goexit()
 }


### PR DESCRIPTION
Add the ability to send the disk full message to slack (we were already
sending the message from input-webhook to Nats). Also fix a bug in
faileddownload handling (it was unmarshalling into newdownload struct,
which just happened to work because the structs are currently the same)